### PR TITLE
Image.open is self closing, del img removes the loaded object

### DIFF
--- a/upload_privacy.py
+++ b/upload_privacy.py
@@ -67,7 +67,8 @@ class LoadImageWithPrivacy:
 
         signature = hmac.new(REMOVE_IMAGE_SECRET.encode('utf-8'), msg=image_path.encode('utf-8'), digestmod=hashlib.sha256).hexdigest()
 
-        img.close()     # so the image file can be removed in later nodes.
+        del img
+
         return (output_image, output_mask, image_path, signature)
 
     @classmethod


### PR DESCRIPTION
Per PIL documentation, the Image.open method is self closing when any operations are performed on the image. Calling Image.close() is only required if Image.open() was called and no operations are performed. 
 https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.load

Replacing: 
```
img.close() 
```

with: 
```
del img
```

deletes the loaded image object

Also the later nodes don't work with the Image object, the image is covered to a tensor, and output_image is a tensor, not a copy of img that was loaded by PIL.