### PR TITLE
changed img open to use node_helpers function to still catch errors.

### DIFF
--- a/upload_privacy.py
+++ b/upload_privacy.py
@@ -74,7 +74,7 @@ class LoadImageIncognito:
             logging.info(f"{image_path} removed.")
 
         # Convert decrypted data to an image
-        img = Image.open(io.BytesIO(decrypted_data))
+        img = node_helpers.pillow(Image.open, io.BytesIO(decrypted_data)) 
         
         output_images = []
         output_masks = []


### PR DESCRIPTION
changed 
```
img = Image.open(io.BytesIO(decrypted_data)) 
```

to 

```
img = node_helpers.pillow(Image.open, io.BytesIO(decrypted_data)) 
```

this allows the fixes that allow proper opening of files that cause pillow errors to still be applied.